### PR TITLE
fix: force optional gum code-signing policy on iOS

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -92,6 +92,16 @@ extern "C" __attribute__((visibility("default")))
 void init(const char *module_names, char *trace_file_path, int thread_id, GUM_OPTIONS* options) {
 
     gum_init();
+    auto code_signing_policy = gum_process_get_code_signing_policy();
+    LOGE("Gum code signing policy before init: %s",
+         gum_code_signing_policy_to_string(code_signing_policy));
+#if PLATFORM_IOS
+    if (code_signing_policy != GUM_CODE_SIGNING_OPTIONAL) {
+        gum_process_set_code_signing_policy(GUM_CODE_SIGNING_OPTIONAL);
+        LOGE("Gum code signing policy forced to: %s",
+             gum_code_signing_policy_to_string(gum_process_get_code_signing_policy()));
+    }
+#endif
 
     GumTrace *instance = GumTrace::get_instance();
     memcpy(&instance->options, options, sizeof(GUM_OPTIONS));


### PR DESCRIPTION
## Summary

Force `GUM_CODE_SIGNING_OPTIONAL` on iOS at `init()` time, so that Stalker-emitted code pages are not rejected by the kernel with `SIGBUS` / `KERN_PROTECTION_FAILURE` on the first instrumented instruction.

Full failure-mode write-up and reproducer: lidongyooo/GumTrace#9

## Change

Single 10-line diff in `src/main.cpp`:

- Log the inherited policy (useful for diagnosing device-side issues from existing runtime log).
- On iOS only, downgrade `GUM_CODE_SIGNING_REQUIRED` → `GUM_CODE_SIGNING_OPTIONAL` before `gum_stalker_new()` is called.
- No change on Android or other platforms.

## Why

In Frida / jailbroken iOS contexts, GumTrace never needs the REQUIRED policy and cannot satisfy it (our injected dylib does not carry the entitlement that Gum's REQUIRED path expects). Inheriting the default REQUIRED on some iOS versions causes Stalker's JIT code pages to be rejected as unsigned, so the first instrumented instruction aborts with `KERN_PROTECTION_FAILURE`. OPTIONAL is the correct setting for this environment.

## Test plan

- [x] Built with `linux_crossbuild_ios.sh`, signed with `ldid -S`.
- [x] Deployed to `iPhone14,7 / iOS 16.1.1`.
- [x] Before the fix: `dlopen` + `init` + `run` — traced thread aborts immediately with `SIGBUS` at a Stalker cache address; zero trace output.
- [x] After the fix: `dlopen` + `init` + `run` — tracing proceeds normally; trace file grows; `unrun` closes cleanly.
- [x] Runtime log shows the two `LOGE` lines (`before: <policy>`, `forced to: optional`) so the transition is visible on device.

## Notes for review

- The fix is deliberately iOS-only via `#if PLATFORM_IOS`. Android and other platforms keep their inherited policy.
- No build-system change, no new options, no behaviour change for existing configurations beyond the documented iOS fix.
